### PR TITLE
Refactor: Replace deprecated PreferenceManager.getDefaultSharedPrefer…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+##  2.7.0-dev.3
+* Replace deprecated [PreferenceManager.getDefaultSharedPreferences] with [context.getSharedPreferences] using "NAVIGATION_SHARE_PREFS"
+##  2.7.0-dev.2
+* Upgraded [NextBillionNavigation] to version 2.5.0 — fixed all native SDK lint issues in this release
+* Upgraded [ai.nextbillion:nb-navigation-android] from 2.1.0 to 2.2.0 — includes native SDK lint fixes
+* Upgraded [nb_maps_flutter] to 2.2.0 — includes native SDK lint fixes
+* Fixed all lint issues detected by [flutter_lints]
+* Fixed all lint issue check by [flutter_lint]
 ## v2.6.0, Mar 14, 2025
 * Upgraded [nb_maps_flutter] to version 2.1.0 to fix error logs when retrieving image resources.
 * Added support for bike and motorcycle modes in route generation.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ android {
 }
 
 dependencies {
-    implementation 'ai.nextbillion:nb-navigation-android:2.2.0'
+    implementation 'ai.nextbillion:nb-navigation-android:2.3.0-beta.2'
 
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.google.android.material:material:1.5.0'

--- a/android/src/main/kotlin/ai/nextbillion/navigation/factory/EmbeddedNavigationViewFactory.kt
+++ b/android/src/main/kotlin/ai/nextbillion/navigation/factory/EmbeddedNavigationViewFactory.kt
@@ -7,6 +7,7 @@ import ai.nextbillion.navigation.nb_navigation_flutter.R
 import ai.nextbillion.navigation.nb_navigation_flutter.databinding.NavigationActivityBinding
 import android.app.Activity
 import android.content.Context
+import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -40,7 +41,10 @@ class EmbeddedNavigationViewFactory(
     }
 
     private fun storeNavThemeConfig(context: Context, args: Any?) {
-        val editor = PreferenceManager.getDefaultSharedPreferences(context).edit()
+        val sharedPreferences: SharedPreferences = context
+            .getSharedPreferences(NavigationConstants.NAVIGATION_SHARE_PREFS, Context.MODE_PRIVATE)
+
+        val editor = sharedPreferences.edit()
         val config = (args as Map<*, *>?)?.get("launcherConfig") as? Map<*, *>
 
         config?.let {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nb_navigation_flutter
 description: A Flutter plugin for Nextbillion.ai Navigation SDK, providing turn-by-turn navigation.
-version: 2.7.0-dev.2
+version: 2.7.0-dev.3
 homepage: https://docs.nextbillion.ai/routing/flutter-navigation-sdk
 repository: https://github.com/nextbillion-ai/nextbillion-navigation-flutter
 


### PR DESCRIPTION
…ences with context.getSharedPreferences using NAVIGATION_SHARE_PREFS

1. Bump Android native SDK to 2.3.0-beta.2 , this version have removed all PreferenceManager.getDefaultSharedPreferences